### PR TITLE
Update suisei-cn/actions-download-file@v1.4.0

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           python-version: "3.11"
 
-      - uses: suisei-cn/actions-download-file@v1
+      - uses: suisei-cn/actions-download-file@v1.4.0
         id: downloadfile # Remember to give an ID if you need the output filename
         name: Download rootfs 
         with:


### PR DESCRIPTION
Update of suisei-cn/actions-download-file@v1.4.0 in the action build to remove Warning during the build